### PR TITLE
Set `stdin` of child process to null

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ extern crate threadpool;
 use structopt::StructOpt;
 use structopt::clap::AppSettings;
 use std::io::{self, BufRead};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use regex::Regex;
 use std::collections::HashMap;
 use std::convert::From;
@@ -133,6 +133,7 @@ impl Rargs {
 
         Command::new(&self.command)
             .args(args)
+            .stdin(Stdio::null())
             .status()
             .expect("command failed to start");
     }


### PR DESCRIPTION
See https://www.reddit.com/r/rust/comments/ebnooh/weird_behaviour_of_command/. The TLDR is because `rargs` shouldn't send data to `stdin` of the child process in any case, and `Command` will by default inherit the `stdin` of the parent process, we should explicitly set that.