### PR TITLE
Readme: add installation instructions on Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 brew install rargs
 ```
 
+### Nix
+
+```
+nix-env -i rargs
+```
+(Currently available in unstable channel)
+
 ### Binary
 
 Download in the [Release Page](https://github.com/lotabout/rargs/releases) and


### PR DESCRIPTION
Since the [PR](https://github.com/NixOS/nixpkgs/pull/95509)  in NixPkgs is merged, `rargs` should be available on NixOs starting from the next build (probably sometime today 22/8/2020)