### PR TITLE
Default to using multi-threading 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ Suppose we have already captured 5 groups representing the strings `1`, `2`, `3`
 
 ### Multiple threading
 
-You can run commands in multiple threads to improve performance:
+By default, `rargs` will use one thread per CPU on your system. You can explicitly specify the
+number of threads to use:
 
-- `-w <num>` specifies the number of workers you want to run simultaneously
-- `-w 0` defaults the number of workers to the number of CPUs on your system
+- `-j <num>` specifies the number of threads you want to run simultaneously
 
 ### Special Variables
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,15 +22,11 @@ fn main() {
 
     let stdin = io::stdin();
 
-    let num_worker = if options.worker > 0 {
-        options.worker
-    } else {
-        num_cpus::get()
-    };
-    let num_threads = if options.threads > 0 {
-        options.threads
-    } else {
-        num_worker
+    let num_threads = match (options.threads, options.worker) {
+        (Some(n), _) if n > 0 => n,
+        // Fall back to using deprecated num_worker for backwards compatibility
+        (None, Some(n)) if n > 0 => n,
+        _ => num_cpus::get(),
     };
 
     let pool = ThreadPool::new(num_threads);
@@ -102,18 +98,16 @@ struct Options {
     #[structopt(
         long = "worker",
         short = "w",
-        default_value = "1",
         help = "Deprecated. Number of threads to be used (same as --threads)"
     )]
-    worker: usize,
+    worker: Option<usize>,
 
     #[structopt(
         long = "threads",
         short = "j",
-        default_value = "1",
-        help = "Number of threads to be used"
+        help = "Number of threads to be used. Defaults to # of CPU's"
     )]
-    threads: usize,
+    threads: Option<usize>,
 
     #[structopt(
         long = "pattern",


### PR DESCRIPTION
To increase performance with the default settings, default to using multi-threading, specifically one
thread per CPU. The user must explicitly opt out if they want
single-threaded behavior, the previous default.

This indirectly solves a different issue: the only way to automatically
peg the number of threads to the number of CPU's was to set
`--worker 0 --threads 0` even though the `worker` argument had been
deprecated.

Fixes #18